### PR TITLE
Filter out draft posts from the notes page

### DIFF
--- a/src/notes/gatsby-rss.md
+++ b/src/notes/gatsby-rss.md
@@ -2,6 +2,7 @@
 path: '/notes/gatsby-rss'
 date: '2019-01-01'
 title: 'Publishing an RSS feed with Gatsby'
+draft: false
 ---
 
 ## Wait, what's RSS?

--- a/src/notes/modeling-relational-data.md
+++ b/src/notes/modeling-relational-data.md
@@ -2,6 +2,7 @@
 path: '/notes/modeling-relational-data'
 date: '2018-12-16'
 title: 'Modeling (and querying) relational data with JavaScript'
+draft: false
 ---
 
 This post describes a way of modeling relational data in JavaScript and shows how the `filter()` and `some()` array methods can be used to query this data. It's not intended to replace a real database, but to show how an array of objects can be filtered based on the contents of another array of objects.

--- a/src/pages/notes.js
+++ b/src/pages/notes.js
@@ -26,7 +26,10 @@ export default class Notes extends React.Component {
 
 export const query = graphql`
   query {
-    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+    allMarkdownRemark(
+      filter: { frontmatter: { draft: { eq: false } } }
+      sort: { fields: [frontmatter___date], order: DESC }
+    ) {
       edges {
         node {
           id
@@ -34,6 +37,7 @@ export const query = graphql`
             path
             title
             date(formatString: "D MMMM YYYY")
+            draft
           }
         }
       }


### PR DESCRIPTION
This partially addresses #17. Posts with `draft: true` in their front matter will not be listed on the notes page. However, they are still built and available if someone were to guess the post's URL.