### PR TITLE
Add site title to notes

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -2,6 +2,7 @@ import { graphql } from 'gatsby';
 import React from 'react';
 import styled from 'styled-components';
 import BackLink from '../BackLink/BackLink';
+import NotesHeader from '../NotesHeader/NotesHeader';
 import Page from '../Page/Page';
 
 const Root = styled.div`
@@ -89,7 +90,7 @@ export default class Note extends React.Component {
     return (
       <Page themeVariant="light">
         <Root>
-          <BackLink title="Notes" to="/notes" />
+          <NotesHeader backTitle="Notes" backTo="/notes" />
           <Title>{frontmatter.title}</Title>
           <Date>{frontmatter.date}</Date>
           <Content dangerouslySetInnerHTML={{ __html: html }} />

--- a/src/components/NotesHeader/NotesHeader.js
+++ b/src/components/NotesHeader/NotesHeader.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+
+const Root = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+`;
+
+const BackLink = styled(Link)`
+  font-size: 20px;
+  font-family: ${props => props.theme.fonts.monospace};
+  text-transform: uppercase;
+  margin-bottom: 40px;
+  display: inline-block;
+
+  /* Prevents height from changing on hover. */
+  /* @todo: Find a better solution to this. */
+  &:hover {
+    margin-bottom: 38px;
+  }
+`;
+
+const Title = styled.div`
+  font-size: 20px;
+  color: ${props => props.theme.colors.secondaryText};
+`;
+
+const NotesHeader = ({ backTo, backTitle }) => (
+  <Root>
+    <BackLink to={backTo}>&larr; {backTitle}</BackLink>
+    <Title>mike wheaton</Title>
+  </Root>
+);
+
+export default NotesHeader;

--- a/src/pages/notes.js
+++ b/src/pages/notes.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 import NoteList from '../components/NoteList/NoteList';
 import Page from '../components/Page/Page';
-import BackLink from '../components/BackLink/BackLink';
+import NotesHeader from '../components/NotesHeader/NotesHeader';
 
 export default class Notes extends React.Component {
   render() {
@@ -17,7 +17,7 @@ export default class Notes extends React.Component {
 
     return (
       <Page>
-        <BackLink title="Home" to="/" />
+        <NotesHeader backTitle="Home" backTo="/" />
         <NoteList notes={notes} />
       </Page>
     );


### PR DESCRIPTION
Closes #19.

Adds 'mike wheaton' to the top of the notes page and each individual note.

![image](https://user-images.githubusercontent.com/1382445/51158835-1f5f7f00-183b-11e9-9b1c-761f84d5d92a.png)
