### PR TITLE
Update notes navigation

### DIFF
--- a/src/components/Note/Note.js
+++ b/src/components/Note/Note.js
@@ -94,7 +94,7 @@ export default class Note extends React.Component {
     return (
       <Page>
         <Root>
-          <NotesHeader backTitle="Home" backTo="/#notes" />
+          <NotesHeader backTitle="Notes" backTo="/#notes" />
           <Title>{frontmatter.title}</Title>
           <Date>{frontmatter.date}</Date>
           <Content dangerouslySetInnerHTML={{ __html: html }} />

--- a/src/components/NotesHeader/NotesHeader.js
+++ b/src/components/NotesHeader/NotesHeader.js
@@ -22,15 +22,17 @@ const BackLink = styled(Link)`
   }
 `;
 
-const Title = styled.div`
+const HomeLink = styled(Link)`
+  border-bottom: none;
   font-size: ${props => props.theme.sizes.small};
-  color: ${props => props.theme.colors.secondaryText};
+  font-weight: bold;
+  text-transform: uppercase;
 `;
 
 const NotesHeader = ({ backTo, backTitle }) => (
   <Root>
     <BackLink to={backTo}>&larr; {backTitle}</BackLink>
-    <Title>mike wheaton</Title>
+    <HomeLink to="/">Mike Wheaton</HomeLink>
   </Root>
 );
 


### PR DESCRIPTION
Changed the back label from 'home' to 'notes' to be clear that it goes to a list of notes and not the home page. Made the site title a link that goes to the top of the home page.